### PR TITLE
Update views.py

### DIFF
--- a/live_streaming/views.py
+++ b/live_streaming/views.py
@@ -1,6 +1,12 @@
-from django.shortcuts import render
+from django.http import JsonResponse
+from camera_integration.models import Camera
+from django.contrib.auth.decorators import login_required
 
-
-def index(request, cam_id):
-    """Video streaming home page."""
-    return render(request, "live_stream.html", context={"cam_id": cam_id})
+@login_required
+def get_hls_url(request, cam_id):
+    try:
+        camera = Camera.objects.get(id=cam_id, user=request.user)
+        stream_url = f"http://your-server-ip:8000/live_{cam_id}.m3u8"
+        return JsonResponse({'stream_url': stream_url})
+    except Camera.DoesNotExist:
+        return JsonResponse({'error': 'Camera not found or access denied'}, status=403)


### PR DESCRIPTION
The CameraConsumer is capturing RTSP frames with OpenCV and sending them over WebSocket — which is:

Bandwidth-heavy

Not browser-friendly

Redundant with the HLS solution you're implementing.  

Since this code is no longer necessary, you can remove it or comment it out. Your new logic should be handled by:

FFmpeg (in the backend) streaming to HLS.

Frontend using hls.js or native HTML5 <video>.